### PR TITLE
Bump to 3.0.0

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -13,17 +13,17 @@ on:
 jobs:
   build:
     name: Build
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
 
     steps:
       - name: Checkout the repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v5
 
       - name: Validate Gradle Wrapper
-        uses: gradle/wrapper-validation-action@v1
+        uses: gradle/wrapper-validation-action@v3
 
       - name: Cache gradle
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: |
             ~/.gradle/caches
@@ -42,11 +42,18 @@ jobs:
 
       - name: Bundle the build report
         if: failure()
-        run: find . -type d -name 'reports' | zip -@ -r build-reports.zip
+        run: |
+            REPORTS=$(find . -type d -name 'reports')
+            if [ -n "$REPORTS" ]; then
+              echo "$REPORTS" | zip -@ -r build-reports.zip
+            else
+              echo "No reports directory found; skipping zip."
+              touch build-reports.zip
+            fi
 
       - name: Upload the build report
         if: failure()
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: error-report
           path: build-reports.zip

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,13 +4,22 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [2.0.3] - Unreleased
+## [3.0.0] - 2025-10-03
 
-[2.0.3]: https://github.com/streem/metrics-datadog/compare/v2.0.2...HEAD
+[3.0.0]: https://github.com/streem/metrics-datadog/compare/v2.0.2...HEAD
 
 ### Added
 
 ### Changed
+
+* Dropwizard 2.1.7 to 3.0.1
+* Jackson: Upgraded jackson from 2.14.1 to 2.18.2 
+* HTTP Components: Updated from 4.5.5 to 4.5.14
+* Datadog Client: Updated from 2.9.0 to 4.4.0
+* JUnit: Updated from 4.13.1 to 4.13.2
+* Mockito: Replaced deprecated mockito-all 1.10.19 with mockito-core 5.14.2
+* SLF4J: Updated from 1.7.25 to 2.0.16
+* DNS Cache Manipulator: Updated from 1.8.1 to 1.8.2
 
 ### Fixed
 
@@ -40,4 +49,3 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Fixed
 
 * Updated `dropwizard-metrics` library from `1.3.4` to `4.0.0` which does not contain any vulnerabilities, see https://mvnrepository.com/artifact/io.dropwizard/dropwizard-metrics/4.0.0
-

--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ First, add the `dropwizard-metrics-datadog` dependency in your POM:
     <dependency>
         <groupId>pro.streem.metrics-datadog</groupId>
         <artifactId>dropwizard-metrics-datadog</artifactId>
-        <version>2.0.2</version>
+        <version>3.0.0</version>
     </dependency>
 ~~~
 
@@ -284,18 +284,18 @@ See above instructions for details.
 ## Maven Info
 
 Metrics datadog reporter is available as an artifact on
-[Maven Central](http://search.maven.org/#search%7Cga%7C1%7Cg%3A%22pro.streem%22%20AND%20a%3A%22metrics-datadog%22)
+[Maven Central](https://mvnrepository.com/artifact/pro.streem.metrics-datadog/metrics-datadog)
 
 * Group: pro.streem.metrics-datadog
 * Artifact: metrics-datadog
-* Version: 2.0.2
+* Version: 3.0.0
 
 Dropwizard datadog reporter is available as an artifact on
-[Maven Central](http://search.maven.org/#search%7Cga%7C1%7Cg%3A%22pro.streem%22%20AND%20a%3A%22dropwizard-metrics-datadog%22)
+[Maven Central](https://mvnrepository.com/artifact/pro.streem.metrics-datadog/dropwizard-metrics-datadog)
 
 * Group: pro.streem.metrics-datadog
 * Artifact: dropwizard-metrics-datadog
-* Version: 2.0.2
+* Version: 3.0.0
 
 ## Contributing
 

--- a/buildSrc/src/main/kotlin/pro.streem.metrics-datadog.java-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/pro.streem.metrics-datadog.java-conventions.gradle.kts
@@ -3,7 +3,7 @@ plugins {
 }
 
 group = "pro.streem.metrics-datadog"
-version = "2.0.3-SNAPSHOT"
+version = "3.0.0"
 
 repositories {
     mavenCentral()

--- a/dropwizard-metrics-datadog/build.gradle.kts
+++ b/dropwizard-metrics-datadog/build.gradle.kts
@@ -10,4 +10,5 @@ dependencies {
     api(libs.dropwizard.metrics.dropwizard)
     testImplementation(libs.junit)
     testImplementation(libs.fest.assert.core)
+    testImplementation(libs.slf4j.simple)
 }

--- a/dropwizard-metrics-datadog/src/main/java/io/dropwizard/metrics/common/DatadogReporterFactory.java
+++ b/dropwizard-metrics-datadog/src/main/java/io/dropwizard/metrics/common/DatadogReporterFactory.java
@@ -1,9 +1,10 @@
-package io.dropwizard.metrics;
+package io.dropwizard.metrics.common;
 
 import com.codahale.metrics.MetricRegistry;
 import com.codahale.metrics.ScheduledReporter;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
+import io.dropwizard.metrics.common.BaseReporterFactory;
 import pro.streem.metrics.datadog.DatadogReporter;
 import pro.streem.metrics.datadog.DefaultMetricNameFormatterFactory;
 import pro.streem.metrics.datadog.DynamicTagsCallbackFactory;

--- a/dropwizard-metrics-datadog/src/main/resources/META-INF/services/io.dropwizard.metrics.ReporterFactory
+++ b/dropwizard-metrics-datadog/src/main/resources/META-INF/services/io.dropwizard.metrics.ReporterFactory
@@ -1,1 +1,0 @@
-io.dropwizard.metrics.DatadogReporterFactory

--- a/dropwizard-metrics-datadog/src/main/resources/META-INF/services/io.dropwizard.metrics.common.ReporterFactory
+++ b/dropwizard-metrics-datadog/src/main/resources/META-INF/services/io.dropwizard.metrics.common.ReporterFactory
@@ -1,0 +1,1 @@
+io.dropwizard.metrics.common.DatadogReporterFactory

--- a/dropwizard-metrics-datadog/src/test/java/io/dropwizard/metrics/DatadogReporterFactoryTest.java
+++ b/dropwizard-metrics-datadog/src/test/java/io/dropwizard/metrics/DatadogReporterFactoryTest.java
@@ -1,5 +1,6 @@
 package io.dropwizard.metrics;
 
+import io.dropwizard.metrics.common.DatadogReporterFactory;
 import io.dropwizard.jackson.DiscoverableSubtypeResolver;
 import org.fest.assertions.api.Assertions;
 import org.junit.Test;

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,17 +1,23 @@
 [versions]
-metrics = "4.0.2"
-jackson = "2.14.1"
-dropwizard = "2.1.7"
+metrics = "4.2.37"
+jackson = "2.18.2"
+dropwizard = "3.0.1"
+httpcomponents = "4.5.14"
+dogstatsd = "4.4.0"
+junit = "4.13.2"
+mockito = "5.14.2"
+slf4j = "2.0.16"
+dnsCacheManipulator = "1.8.3"
 
 [libraries]
 dropwizard-metrics-core = { group = "io.dropwizard.metrics", name = "metrics-core", version.ref = "metrics" }
 dropwizard-metrics-dropwizard = { group = "io.dropwizard", name = "dropwizard-metrics", version.ref = "dropwizard" }
-httpcomponents-fluentHc = { group = "org.apache.httpcomponents", name = "fluent-hc", version = "4.5.5" }
+httpcomponents-fluentHc = { group = "org.apache.httpcomponents", name = "fluent-hc", version.ref = "httpcomponents" }
 jackson-databind = { group = "com.fasterxml.jackson.core", name = "jackson-databind", version.ref = "jackson" }
-dogstatsd-client = { group = "com.datadoghq", name = "java-dogstatsd-client", version = "2.9.0" }
+dogstatsd-client = { group = "com.datadoghq", name = "java-dogstatsd-client", version.ref = "dogstatsd" }
 
-junit = { group = "junit", name = "junit", version = "4.13.1" }
+junit = { group = "junit", name = "junit", version.ref = "junit" }
 fest-assert-core = { group = "org.easytesting", name = "fest-assert-core", version = "2.0M10" }
-mockito-all = { group = "org.mockito", name = "mockito-all", version = "1.10.19" }
-slf4j-simple = { group = "org.slf4j", name = "slf4j-simple", version = "1.7.25" }
-dnsCacheManipulator = { group = "com.alibaba", name = "dns-cache-manipulator", version = "1.8.1" }
+mockito-core = { group = "org.mockito", name = "mockito-core", version.ref = "mockito" }
+slf4j-simple = { group = "org.slf4j", name = "slf4j-simple", version.ref = "slf4j" }
+dnsCacheManipulator = { group = "com.alibaba", name = "dns-cache-manipulator", version.ref = "dnsCacheManipulator" }

--- a/metrics-datadog/build.gradle.kts
+++ b/metrics-datadog/build.gradle.kts
@@ -12,7 +12,7 @@ dependencies {
     api(libs.dogstatsd.client)
 
     testImplementation(libs.junit)
-    testImplementation(libs.mockito.all)
+    testImplementation(libs.mockito.core)
     testImplementation(libs.slf4j.simple)
     testImplementation(libs.dnsCacheManipulator)
 }

--- a/metrics-datadog/src/main/java/pro/streem/metrics/datadog/transport/UdpTransport.java
+++ b/metrics-datadog/src/main/java/pro/streem/metrics/datadog/transport/UdpTransport.java
@@ -1,6 +1,7 @@
 package pro.streem.metrics.datadog.transport;
 
 import com.timgroup.statsd.NonBlockingStatsDClient;
+import com.timgroup.statsd.NonBlockingStatsDClientBuilder;
 import com.timgroup.statsd.StatsDClient;
 import com.timgroup.statsd.StatsDClientErrorHandler;
 import pro.streem.metrics.datadog.model.DatadogCounter;
@@ -31,24 +32,26 @@ public class UdpTransport implements Transport {
 
   private UdpTransport(String prefix, String statsdHost, int port, boolean isRetryingLookup, String[] globalTags) {
     final Callable<SocketAddress> socketAddressCallable;
-
     if(isRetryingLookup) {
       socketAddressCallable = volatileAddressResolver(statsdHost, port);
     } else {
       socketAddressCallable = staticAddressResolver(statsdHost, port);
     }
 
-    statsd = new NonBlockingStatsDClient(
-            prefix,
-            Integer.MAX_VALUE,
-            globalTags,
-            new StatsDClientErrorHandler() {
+    NonBlockingStatsDClientBuilder builder = new NonBlockingStatsDClientBuilder()
+            .addressLookup(socketAddressCallable)
+            .constantTags(globalTags)
+            .errorHandler(new StatsDClientErrorHandler() {
               public void handle(Exception e) {
                 LOG.error(e.getMessage(), e);
               }
-            },
-            socketAddressCallable
-    );
+            });
+    
+    if (prefix != null) {
+      builder.prefix(prefix);
+    }
+    
+    statsd = builder.build();
   }
 
   public void close() throws IOException {
@@ -155,16 +158,18 @@ public class UdpTransport implements Transport {
 
   // Visible for testing.
   static Callable<SocketAddress> staticAddressResolver(final String host, final int port) {
-    try {
-      return NonBlockingStatsDClient.staticAddressResolution(host, port);
-    } catch(final Exception e) {
-      LOG.error("Error during constructing statsd address resolver.", e);
-      throw new RuntimeException(e);
-    }
+    return () -> {
+      try {
+        return new java.net.InetSocketAddress(java.net.InetAddress.getByName(host), port);
+      } catch(final Exception e) {
+        LOG.error("Error during constructing statsd address resolver.", e);
+        throw new RuntimeException(e);
+      }
+    };
   }
 
   // Visible for testing.
   static Callable<SocketAddress> volatileAddressResolver(final String host, final int port) {
-    return NonBlockingStatsDClient.volatileAddressResolution(host, port);
+    return () -> new java.net.InetSocketAddress(java.net.InetAddress.getByName(host), port);
   }
 }

--- a/metrics-datadog/src/test/java/pro/streem/metrics/datadog/transport/UdpTransportTest.java
+++ b/metrics-datadog/src/test/java/pro/streem/metrics/datadog/transport/UdpTransportTest.java
@@ -48,7 +48,7 @@ public class UdpTransportTest {
 
     try {
       retryingCallable.call();
-      assertFalse(true);
+        fail();
     } catch (final Exception e) {}
     // ^ This should throw becuase the host is unresolvable.
 


### PR DESCRIPTION
Add support for drop-wizard 3 

* Dropwizard 2.1.7 to 3.0.1
* Jackson from 2.14.1 to 2.18.2
* HTTP Components: Updated from 4.5.5 to 4.5.14
* Datadog Client: Updated from 2.9.0 to 4.4.0
* JUnit: Updated from 4.13.1 to 4.13.2
* Mockito: Replaced deprecated mockito-all 1.10.19 with mockito-core 5.14.2
* SLF4J: Updated from 1.7.25 to 2.0.16
* DNS Cache Manipulator: Updated from 1.8.1 to 1.8.2